### PR TITLE
Add new ideologies and economy scaffolding

### DIFF
--- a/mod/echoes_of_the_new_dawn/common/decisions/eotnd_economy_decisions.txt
+++ b/mod/echoes_of_the_new_dawn/common/decisions/eotnd_economy_decisions.txt
@@ -1,0 +1,38 @@
+decision_categories = {
+    eotnd_economy_category = {
+        icon = generic_production
+        decisions = {
+            eotnd_increase_taxes = {
+                cost = 50
+                available = { }
+                visible = { always = yes }
+                complete_effect = {
+                    eotnd_add_money = { value = 100 }
+                }
+            }
+
+            eotnd_decrease_taxes = {
+                cost = 50
+                available = { }
+                visible = { always = yes }
+                complete_effect = {
+                    eotnd_add_money = { value = -100 }
+                }
+            }
+
+            eotnd_give_aid = {
+                cost = 100
+                available = { }
+                visible = { always = yes }
+                target_trigger = { is_country = yes }
+                target_effect = {
+                    eotnd_add_money = { value = 100 }
+                    eotnd_add_influence = { value = 10 }
+                }
+                complete_effect = {
+                    eotnd_add_money = { value = -100 }
+                }
+            }
+        }
+    }
+}

--- a/mod/echoes_of_the_new_dawn/common/defines/eotnd_economy_defines.txt
+++ b/mod/echoes_of_the_new_dawn/common/defines/eotnd_economy_defines.txt
@@ -1,0 +1,5 @@
+NDefines = {
+    NCountry = {
+        EOTND_INTEREST_RATE = 0.05
+    }
+}

--- a/mod/echoes_of_the_new_dawn/common/ideologies/00_eotnd_ideologies.txt
+++ b/mod/echoes_of_the_new_dawn/common/ideologies/00_eotnd_ideologies.txt
@@ -1,0 +1,48 @@
+ideologies = {
+    fascism = {
+        types = {
+            generic_fascism = {
+                can_start_civil_war = yes
+                ai_will_do = { factor = 1 }
+            }
+        }
+    }
+
+    communism = {
+        types = {
+            generic_communism = {
+                can_start_civil_war = yes
+                ai_will_do = { factor = 1 }
+            }
+        }
+    }
+
+    democratic = {
+        types = {
+            generic_democratic = {
+                can_start_civil_war = yes
+                ai_will_do = { factor = 1 }
+            }
+        }
+    }
+
+    monarchism = {
+        types = {
+            monarchism = {
+                can_start_civil_war = yes
+                ai_will_do = { factor = 1 }
+                icon = "GFX_ideology_monarchism"
+            }
+        }
+    }
+
+    militarist_collectivism = {
+        types = {
+            militarist_collectivism = {
+                can_start_civil_war = yes
+                ai_will_do = { factor = 1 }
+                icon = "GFX_ideology_militarist_collectivism"
+            }
+        }
+    }
+}

--- a/mod/echoes_of_the_new_dawn/common/on_actions/00_eotnd_on_actions.txt
+++ b/mod/echoes_of_the_new_dawn/common/on_actions/00_eotnd_on_actions.txt
@@ -1,0 +1,4 @@
+on_actions = {
+    on_startup = { eotnd_initialize_economy = yes }
+    monthly = { country_event = { id = eotnd_economy.1 } }
+}

--- a/mod/echoes_of_the_new_dawn/common/scripted_effects/eotnd_economy_effects.txt
+++ b/mod/echoes_of_the_new_dawn/common/scripted_effects/eotnd_economy_effects.txt
@@ -1,0 +1,31 @@
+eotnd_add_money = {
+    add_to_variable = { money = value }
+}
+
+eotnd_add_debt = {
+    add_to_variable = { debt = value }
+}
+
+eotnd_add_influence = {
+    add_to_variable = { influence = value }
+}
+
+eotnd_monthly_economy_tick = {
+    # pay interest
+    temp_variable = debt
+    multiply_variable = { temp_variable = 0.05 }
+    add_to_variable = { money = -temp_variable }
+    clr_variable = temp_variable
+
+    # influence decay
+    temp_variable = influence
+    multiply_variable = { temp_variable = 0.02 }
+    add_to_variable = { influence = -temp_variable }
+    clr_variable = temp_variable
+}
+
+eotnd_initialize_economy = {
+    set_variable = { money = 1000 }
+    set_variable = { debt = 0 }
+    set_variable = { influence = 0 }
+}

--- a/mod/echoes_of_the_new_dawn/events/eotnd_economy_events.txt
+++ b/mod/echoes_of_the_new_dawn/events/eotnd_economy_events.txt
@@ -1,0 +1,8 @@
+country_event = {
+    id = eotnd_economy.1
+    hide_window = yes
+    is_triggered_only = yes
+    immediate = {
+        eotnd_monthly_economy_tick = yes
+    }
+}

--- a/mod/echoes_of_the_new_dawn/interface/eotnd_economy_gui.gui
+++ b/mod/echoes_of_the_new_dawn/interface/eotnd_economy_gui.gui
@@ -1,0 +1,25 @@
+guiTypes = {
+    containerWindowType = {
+        name = "eotnd_economy_window"
+        position = { x = 10 y = 10 }
+        size = { width = 220 height = 120 }
+        moveable = yes
+        children = {
+            instantTextBoxType = {
+                name = "money_text"
+                position = { x = 10 y = 10 }
+                text = "MONEY: [?money|0]"
+            }
+            instantTextBoxType = {
+                name = "debt_text"
+                position = { x = 10 y = 40 }
+                text = "DEBT: [?debt|0]"
+            }
+            instantTextBoxType = {
+                name = "influence_text"
+                position = { x = 10 y = 70 }
+                text = "INFLUENCE: [?influence|0]"
+            }
+        }
+    }
+}

--- a/mod/echoes_of_the_new_dawn/localisation/english/eotnd_economy_l_english.yml
+++ b/mod/echoes_of_the_new_dawn/localisation/english/eotnd_economy_l_english.yml
@@ -1,0 +1,13 @@
+l_english:
+ MONARCHISM:0 "Monarchism"
+ MILITARIST_COLLECTIVISM:0 "Militarist Collectivism"
+ eotnd_economy_category:0 "Economic Policies"
+ eotnd_increase_taxes:0 "Increase Taxes"
+ eotnd_increase_taxes_desc:0 "Raise taxes to generate more money."
+ eotnd_decrease_taxes:0 "Decrease Taxes"
+ eotnd_decrease_taxes_desc:0 "Lower taxes to appease the populace."
+ eotnd_give_aid:0 "Provide Financial Aid"
+ eotnd_give_aid_desc:0 "Send money to another nation to gain influence."
+ MONEY_LABEL:0 "Money"
+ DEBT_LABEL:0 "Debt"
+ INFLUENCE_LABEL:0 "Influence"


### PR DESCRIPTION
## Summary
- replace vanilla ideologies and remove neutrality
- add Monarchism and Militarist Collectivism ideologies
- prototype economic system with money, debt, influence variables, decisions, events, GUI, and localisation

## Testing
- `echo "No test suite provided"`


------
https://chatgpt.com/codex/tasks/task_e_68c44b7ae798832dbbf62510cc4d9e90