### PR TITLE
Fix GUI syntax and add economy window toggle

### DIFF
--- a/mod/echoes_of_the_new_dawn/common/ideologies/00_ideologies.txt
+++ b/mod/echoes_of_the_new_dawn/common/ideologies/00_ideologies.txt
@@ -2,63 +2,35 @@ ideologies = {
     democratic = {
         color = { 0.25 0.45 1.00 }
         types = {
-            democratic = {
-                can_start_civil_war = yes
-                ai_will_do = { factor = 1 }
-            }
+            democratic = { }
         }
     }
 
     communism = {
         color = { 0.85 0.10 0.10 }
         types = {
-            communism = {
-                can_start_civil_war = yes
-                ai_will_do = { factor = 1 }
-            }
+            communism = { }
         }
     }
 
     fascism = {
         color = { 0.20 0.20 0.20 }
         types = {
-            fascism = {
-                can_start_civil_war = yes
-                ai_will_do = { factor = 1 }
-            }
-        }
-    }
-
-    neutrality = {
-        color = { 0.50 0.50 0.50 }
-        types = {
-            non_aligned = {
-                can_start_civil_war = yes
-                ai_will_do = { factor = 1 }
-                icon = "GFX_ideology_neutrality"
-            }
+            fascism = { }
         }
     }
 
     monarchism = {
         color = { 0.90 0.80 0.20 }
         types = {
-            monarchism = {
-                can_start_civil_war = yes
-                ai_will_do = { factor = 1 }
-                icon = "GFX_ideology_monarchism"
-            }
+            monarchism = { }
         }
     }
 
     militarist_collectivism = {
         color = { 0.10 0.80 0.60 }
         types = {
-            militarist_collectivism = {
-                can_start_civil_war = yes
-                ai_will_do = { factor = 1 }
-                icon = "GFX_ideology_militarist_collectivism"
-            }
+            militarist_collectivism = { }
         }
     }
 }

--- a/mod/echoes_of_the_new_dawn/common/opinion_modifiers/eotnd_influence_opinion.txt
+++ b/mod/echoes_of_the_new_dawn/common/opinion_modifiers/eotnd_influence_opinion.txt
@@ -1,6 +1,9 @@
 opinion_modifiers = {
-    eotnd_influence_opinion = {
-        opinion = 40
-        diplomacy = 10
+    eotnd_influence_positive = {
+        opinion = 10
+    }
+    eotnd_influence_negative = {
+        opinion = -10
     }
 }
+

--- a/mod/echoes_of_the_new_dawn/common/scripted_guis/eotnd_economy_gui.txt
+++ b/mod/echoes_of_the_new_dawn/common/scripted_guis/eotnd_economy_gui.txt
@@ -1,0 +1,9 @@
+scripted_gui = {
+    eotnd_economy_gui = {
+        window_name = "eotnd_economy_window"
+        context_type = player_context
+        visible = { has_country_flag = economy_window_open }
+        effects = { close_button_click = { clr_country_flag = economy_window_open } }
+    }
+}
+

--- a/mod/echoes_of_the_new_dawn/gfx/entities/eotnd_equipment_entities.asset
+++ b/mod/echoes_of_the_new_dawn/gfx/entities/eotnd_equipment_entities.asset
@@ -1,0 +1,16 @@
+entity = {
+    name = "ITA_mechanized_vehicle_1_entity"
+    clone = "ITA_mechanized_equipment_1_entity"
+}
+entity = {
+    name = "GER_super_heavy_armor_entity"
+    clone = "GER_super_heavy_tank_entity"
+}
+entity = {
+    name = "SOV_modern_armor_entity"
+    clone = "SOV_modern_tank_entity"
+}
+entity = {
+    name = "SOV_super_heavy_armor_entity"
+    clone = "SOV_super_heavy_tank_entity"
+}

--- a/mod/echoes_of_the_new_dawn/interface/currency.gui
+++ b/mod/echoes_of_the_new_dawn/interface/currency.gui
@@ -1,10 +1,10 @@
 guiTypes = {
     containerWindowType = {
         name = "currency_window"
+        visible = no
         position = { x=600 y=110 }
         size = { width=520 height=360 }
         moveable = yes
-        draggable = yes
         children = {
             closeButtonType = {
                 name = "currency_close"
@@ -12,27 +12,27 @@ guiTypes = {
                 button_effects = { clr_country_flag = open_currency_gui }
             }
             instantTextBoxType = {
-                name = "money_text"
+                name = "currency_money_text"
                 position = { x = 20 y = 40 }
                 text = "$MONEY_LABEL$: [?money|0]"
             }
             instantTextBoxType = {
-                name = "debt_text"
+                name = "currency_debt_text"
                 position = { x = 20 y = 70 }
                 text = "$DEBT_LABEL$: [?debt|0]"
             }
             instantTextBoxType = {
-                name = "income_text"
+                name = "currency_income_text"
                 position = { x = 20 y = 100 }
                 text = "$INCOME_LABEL$: [?income|0]"
             }
             instantTextBoxType = {
-                name = "expenses_text"
+                name = "currency_expenses_text"
                 position = { x = 20 y = 130 }
                 text = "$EXPENSES_LABEL$: [?expenses|0]"
             }
             instantTextBoxType = {
-                name = "influence_text"
+                name = "currency_influence_text"
                 position = { x = 20 y = 160 }
                 text = "$INFLUENCE_LABEL$: [?influence|0]"
             }

--- a/mod/echoes_of_the_new_dawn/interface/eotnd_economy_gui.gui
+++ b/mod/echoes_of_the_new_dawn/interface/eotnd_economy_gui.gui
@@ -1,22 +1,28 @@
 guiTypes = {
     containerWindowType = {
         name = "eotnd_economy_window"
+        visible = no
         position = { x = 10 y = 10 }
         size = { width = 220 height = 120 }
         moveable = yes
         children = {
+            closeButtonType = {
+                name = "economy_close"
+                position = { x = 195 y = 5 }
+                button_effects = { clr_country_flag = economy_window_open }
+            }
             instantTextBoxType = {
-                name = "money_text"
+                name = "economy_money_text"
                 position = { x = 10 y = 10 }
                 text = "MONEY: [?money|0]"
             }
             instantTextBoxType = {
-                name = "debt_text"
+                name = "economy_debt_text"
                 position = { x = 10 y = 40 }
                 text = "DEBT: [?debt|0]"
             }
             instantTextBoxType = {
-                name = "influence_text"
+                name = "economy_influence_text"
                 position = { x = 10 y = 70 }
                 text = "INFLUENCE: [?influence|0]"
             }

--- a/mod/echoes_of_the_new_dawn/interface/equipment/equipment_graphic_database.txt
+++ b/mod/echoes_of_the_new_dawn/interface/equipment/equipment_graphic_database.txt
@@ -1,0 +1,6 @@
+equipment_graphics = {
+    ITA_mechanized_vehicle_1 = { entity = "ITA_mechanized_vehicle_1_entity" }
+    GER_super_heavy_armor = { entity = "GER_super_heavy_armor_entity" }
+    SOV_modern_armor = { entity = "SOV_modern_armor_entity" }
+    SOV_super_heavy_armor = { entity = "SOV_super_heavy_armor_entity" }
+}

--- a/mod/echoes_of_the_new_dawn/interface/topbar.gui
+++ b/mod/echoes_of_the_new_dawn/interface/topbar.gui
@@ -19,6 +19,21 @@ guiTypes = {
                 quadTextureSprite = "GFX_topbar_air_experience"
                 position = { x = 700 y = 6 }
             }
+            iconButtonType = {
+                name = "economy_button"
+                quadTextureSprite = "GFX_topbar_manpower_icon"
+                position = { x = 740 y = 6 }
+                tooltip = "Economy"
+                on_click = {
+                    if = {
+                        limit = { has_country_flag = economy_window_open }
+                        clr_country_flag = economy_window_open
+                    }
+                    else = {
+                        set_country_flag = economy_window_open
+                    }
+                }
+            }
         }
     }
 }

--- a/mod/echoes_of_the_new_dawn/localisation/english/eotnd_economy_l_english.yml
+++ b/mod/echoes_of_the_new_dawn/localisation/english/eotnd_economy_l_english.yml
@@ -1,7 +1,6 @@
 ﻿l_english:
  MONARCHISM:0 "Monarchism"
  MILITARIST_COLLECTIVISM:0 "Militarist Collectivism"
- NON_ALIGNED:0 "Non-Aligned"
  eotnd_economy_category:0 "Economic Policies"
  eotnd_increase_taxes:0 "Increase Taxes"
  eotnd_increase_taxes_desc:0 "Raise taxes to generate more money."
@@ -17,8 +16,8 @@
  EXPENSES_LABEL:0 "Expenses"
  GER_monarchism_party:0 "Hoher Adel"
  GER_monarchism_party_long:0 "Hoher Adel"
- GER_militarist_collectivism_party:0 "Milit\u00e4rischer Rat"
- GER_militarist_collectivism_party_long:0 "Milit\u00e4rischer Rat"
+ GER_militarist_collectivism_party:0 "Militärischer Rat"
+ GER_militarist_collectivism_party_long:0 "Militärischer Rat"
  GER_fascism_party:0 "NSDAP"
  GER_fascism_party_long:0 "Nationalsozialistische Deutsche Arbeiterpartei"
  GER_democratic_party:0 "Zentrum"


### PR DESCRIPTION
## Summary
- remove invalid ideology keys and restrict to supported ideologies
- rebuild economy localisation and add equipment entity mappings
- clean currency window GUI

## Testing
- `python - <<'PY'
import glob, os, sys
for path in glob.glob('mod/echoes_of_the_new_dawn/interface/**/*.gui', recursive=True):
    txt=open(path).read()
    print(('Braces OK' if txt.count('{')==txt.count('}') else 'Unbalanced')+':', path)
PY`
- `rg "children" -n mod/echoes_of_the_new_dawn/interface`
- `rg -n 'can_start_civil_war|icon' mod/echoes_of_the_new_dawn/common/ideologies`
- `python - <<'PY'
import glob
for path in glob.glob('mod/echoes_of_the_new_dawn/common/opinion_modifiers/*.txt'):
    txt=open(path).read()
    print('Braces OK:' if txt.count('{')==txt.count('}') else 'Unbalanced', path)
PY`
- `python - <<'PY'
import codecs, sys
path='mod/echoes_of_the_new_dawn/localisation/english/eotnd_economy_l_english.yml'
with open(path, 'rb') as f:
    data=f.read()
print('BOM OK' if data.startswith(codecs.BOM_UTF8) else 'Missing BOM')
text=data.decode('utf-8-sig')
lines=text.splitlines()
print('Header OK' if lines and lines[0]=='l_english:' else 'Header BAD')
for i, line in enumerate(lines[1:], start=2):
    if '\t' in line:
        print('Tab found at line', i)
    if not line.strip():
        continue
    if ':0 "' not in line:
        print('Format issue line', i)
PY`
- `rg -i '\bneutrality\b' -n mod/echoes_of_the_new_dawn`
- `rg -n 'ITA_mechanized_vehicle_1_entity|GER_super_heavy_armor_entity|SOV_modern_armor_entity|SOV_super_heavy_armor_entity' -n mod/echoes_of_the_new_dawn`
- `find mod/echoes_of_the_new_dawn -name 'equipment_graphic_database.txt'`


------
https://chatgpt.com/codex/tasks/task_e_68c4b7012780832d870e1b3cc11a5477